### PR TITLE
xDnsRecord: Issue 67 No Ability to set a Custom TTL

### DIFF
--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -1,3 +1,7 @@
+# Import the Helper module
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+Import-Module -Name (Join-Path -Path $modulePath -ChildPath (Join-Path -Path Helper -ChildPath Helper.psm1))
+
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
     -ResourceName 'MSFT_xDnsRecord' `

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -4,9 +4,7 @@ Import-Module -Name (Join-Path -Path $modulePath -ChildPath (Join-Path -Path Hel
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
-    -ResourceName 'MSFT_xDnsRecord' `
-    -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
-
+    -ResourceName 'MSFT_xDnsRecord'
 
 <#
     .SYNOPSIS
@@ -313,11 +311,10 @@ function Test-TargetResource
             return $false
         }
 
-        if (($null -ne $TimeToLive) -and ($result.TimeToLive -ne $TimeToLive))
+        if ( $TimeToLive -and $result.TimeToLive -ne $TimeToLive)
         {
             $stringActualTimeToLive = $result.TimeToLive.ToString()
-            $stringExpectedTimeToLive = $TimeToLive.ToString()
-            Write-Verbose -Message ($LocalizedData.IncorrectTtlMessage -f $stringExpectedTimeToLive, $stringActualTimeToLive)
+            Write-Verbose -Message ($LocalizedData.IncorrectTtlMessage -f $TimeToLive, $stringActualTimeToLive)
             return $false
         }
     }

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -66,7 +66,7 @@ function Get-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
-        [System.TimeSpan]
+        [System.String]
         $TimeToLive
     )
 
@@ -164,7 +164,7 @@ function Set-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
-        [System.TimeSpan]
+        [System.String]
         $TimeToLive
     )
 
@@ -287,7 +287,7 @@ function Test-TargetResource
         $Ensure = 'Present',
 
         [Parameter()]
-        [System.TimeSpan]
+        [System.String]
         $TimeToLive
     )
 

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
@@ -6,6 +6,7 @@ class MSFT_xDnsRecord : OMI_BaseResource
     [Required, Description("Specifies the type of DNS record."), ValueMap{"ARecord","CName","Ptr"}, Values{"ARecord","CName","Ptr"}] string Type;
     [Key, Description("Specifies the Target Hostname or IP Address.")] string Target;
     [Write, Description("Name of the DnsServer to create the record on.")] string DnsServer;
-    [Write, Description("Should this DNS resource record be present or absent"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Should this DNS resource record be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies the Time-To-Live for the record created.")] timespan TimeToLive;
 };
 

--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
@@ -7,6 +7,6 @@ class MSFT_xDnsRecord : OMI_BaseResource
     [Key, Description("Specifies the Target Hostname or IP Address.")] string Target;
     [Write, Description("Name of the DnsServer to create the record on.")] string DnsServer;
     [Write, Description("Should this DNS resource record be present or absent."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
-    [Write, Description("Specifies the Time-To-Live for the record created.")] timespan TimeToLive;
+    [Write, Description("Specifies the Time-To-Live for the record created.")] string TimeToLive;
 };
 

--- a/DSCResources/MSFT_xDnsRecord/en-us/MSFT_xDnsRecord.strings.psd1
+++ b/DSCResources/MSFT_xDnsRecord/en-us/MSFT_xDnsRecord.strings.psd1
@@ -1,0 +1,9 @@
+ConvertFrom-StringData @'
+    GettingDnsRecordMessage   = Getting DNS record '{0}' ({1}) in zone '{2}', from '{3}'.
+    CreatingDnsRecordMessage  = Creating DNS record '{0}' for target '{1}' in zone '{2}' on '{3}'.
+    RemovingDnsRecordMessage  = Removing DNS record '{0}' for target '{1}' in zone '{2}' on '{3}'.
+    NotDesiredPropertyMessage = DNS record property '{0}' is not correct. Expected '{1}', actual '{2}'
+    InDesiredStateMessage     = DNS record '{0}' is in the desired state.
+    NotInDesiredStateMessage  = DNS record '{0}' is NOT in the desired state.
+    IncorrectTtlMessage       = DNS record TTL is not in the desired state. Expected '{0}', actual '{1}'
+'@

--- a/Modules/Helper/Helper.psm1
+++ b/Modules/Helper/Helper.psm1
@@ -27,31 +27,21 @@ function Get-LocalizedData
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
+        [String]
         $ResourceName,
 
-        [Parameter()]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ScriptRoot
+        [String]
+        $ResourcePath
     )
 
-    if (-not $ScriptRoot)
-    {
-        $dscResourcesFolder = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'DSCResources'
-        $resourceDirectory = Join-Path -Path $dscResourcesFolder -ChildPath $ResourceName
-    }
-    else
-    {
-        $resourceDirectory = $ScriptRoot
-    }
-
-    $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath $PSUICulture
+    $localizedStringFileLocation = Join-Path -Path $ResourcePath -ChildPath $PSUICulture
 
     if (-not (Test-Path -Path $localizedStringFileLocation))
     {
         # Fallback to en-US
-        $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath 'en-US'
+        $localizedStringFileLocation = Join-Path -Path $ResourcePath -ChildPath 'en-US'
     }
 
     Import-LocalizedData `
@@ -618,4 +608,4 @@ function Convert-RootHintsToHashtable
 }
 
 # Import Localization Strings
-$script:localizedData = Get-LocalizedData -ResourceName Helper -ScriptRoot $PSScriptRoot
+$script:localizedData = Get-LocalizedData -ResourceName Helper -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)

--- a/Modules/Helper/Helper.psm1
+++ b/Modules/Helper/Helper.psm1
@@ -27,21 +27,31 @@ function Get-LocalizedData
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $ResourceName,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [String]
-        $ResourcePath
+        [System.String]
+        $ScriptRoot
     )
 
-    $localizedStringFileLocation = Join-Path -Path $ResourcePath -ChildPath $PSUICulture
+    if (-not $ScriptRoot)
+    {
+        $dscResourcesFolder = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'DSCResources'
+        $resourceDirectory = Join-Path -Path $dscResourcesFolder -ChildPath $ResourceName
+    }
+    else
+    {
+        $resourceDirectory = $ScriptRoot
+    }
+
+    $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath $PSUICulture
 
     if (-not (Test-Path -Path $localizedStringFileLocation))
     {
         # Fallback to en-US
-        $localizedStringFileLocation = Join-Path -Path $ResourcePath -ChildPath 'en-US'
+        $localizedStringFileLocation = Join-Path -Path $resourceDirectory -ChildPath 'en-US'
     }
 
     Import-LocalizedData `
@@ -608,4 +618,4 @@ function Convert-RootHintsToHashtable
 }
 
 # Import Localization Strings
-$script:localizedData = Get-LocalizedData -ResourceName Helper -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+$script:localizedData = Get-LocalizedData -ResourceName Helper -ScriptRoot $PsScriptRoot

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
   * If not specified, defaults to 'localhost'.
 * **Type**: DNS Record Type.
   * Values include: { ARecord | CName | Ptr }
+* **TimeToLive**: Specifies the Time-To-Live for the record created.
 * **Ensure**: Whether the host record should be present or removed
 
 ### xDnsServerSetting
@@ -230,6 +231,9 @@ Requires Windows Server 2016 onwards
 ## Versions
 
 ### Unreleased
+* Changes to xDnsRecord
+  * Updated with TTL parameter
+    ([issue #67](https://github.com/PowerShell/xDnsServer/issues/67)).
 
 ### 1.15.0.0
 
@@ -498,11 +502,12 @@ configuration Sample_Arecord
     Import-DscResource -module xDnsServer
     xDnsRecord TestRecord
     {
-        Name = "testArecord"
-        Target = "192.168.0.123"
-        Zone = "contoso.com"
-        Type = "ARecord"
-        Ensure = "Present"
+        Name       = "testArecord"
+        Target     = "192.168.0.123"
+        Zone       = "contoso.com"
+        Type       = "ARecord"
+        TimeToLive = "02:00:00"
+        Ensure     = "Present"
     }
 }
 Sample_Arecord
@@ -516,18 +521,19 @@ configuration Sample_RoundRobin_Arecord
     Import-DscResource -module xDnsServer
     xDnsRecord TestRecord1
     {
-        Name = "testArecord"
-        Target = "192.168.0.123"
-        Zone = "contoso.com"
-        Type = "ARecord"
-        Ensure = "Present"
+        Name       = "testArecord"
+        Target     = "192.168.0.123"
+        Zone       = "contoso.com"
+        Type       = "ARecord"
+        TimeToLive = "02:00:00"
+        Ensure     = "Present"
     }
     xDnsRecord TestRecord2
     {
-        Name = "testArecord"
+        Name   = "testArecord"
         Target = "192.168.0.124"
-        Zone = "contoso.com"
-        Type = "ARecord"
+        Zone   = "contoso.com"
+        Type   = "ARecord"
         Ensure = "Present"
     }
 
@@ -543,11 +549,12 @@ configuration Sample_CName
     Import-DscResource -module xDnsServer
     xDnsRecord TestRecord
     {
-        Name = "testCName"
-        Target = "test.contoso.com"
-        Zone = "contoso.com"
-        Type = "CName"
-        Ensure = "Present"
+        Name       = "testCName"
+        Target     = "test.contoso.com"
+        Zone       = "contoso.com"
+        Type       = "CName"
+        TimeToLive = "02:00:00"
+        Ensure     = "Present"
     }
 }
 Sample_Crecord
@@ -561,11 +568,12 @@ configuration Sample_Ptr
     Import-DscResource -module xDnsServer
     xDnsRecord TestPtrRecord
     {
-        Name = "123"
-        Target = "TestA.contoso.com"
-        Zone = "0.168.192.in-addr.arpa"
-        Type = "PTR"
-        Ensure = "Present"
+        Name       = "123"
+        Target     = "TestA.contoso.com"
+        Zone       = "0.168.192.in-addr.arpa"
+        Type       = "PTR"
+        TimeToLive = "02:00:00"
+        Ensure     = "Present"
     }
 }
 Sample_Ptr
@@ -579,10 +587,10 @@ configuration Sample_Remove_Record
     Import-DscResource -module xDnsServer
     xDnsARecord RemoveTestRecord
     {
-        Name = "testArecord"
+        Name   = "testArecord"
         Target = "192.168.0.123"
-        Zone = "contoso.com"
-        Type = "ARecord"
+        Zone   = "contoso.com"
+        Type   = "ARecord"
         Ensure = "Absent"
     }
 }

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Requires Windows Server 2016 onwards
 ## Versions
 
 ### Unreleased
+
 * Changes to xDnsRecord
   * Updated with TTL parameter
     ([issue #67](https://github.com/PowerShell/xDnsServer/issues/67)).

--- a/README.md
+++ b/README.md
@@ -235,6 +235,11 @@ Requires Windows Server 2016 onwards
 * Changes to xDnsRecord
   * Updated with TTL parameter
     ([issue #67](https://github.com/PowerShell/xDnsServer/issues/67)).
+* Changes to XDnsServerADZone
+  * Raise an exception if `DirectoryPartitionName` is specified and `ReplicationScope` is not `Custom`.
+  ([issue #110](https://github.com/PowerShell/xDnsServer/issues/110)).
+  * Enforce the `ReplicationScope` parameter being passed to `Set-DnsServerPrimaryZone` if
+  `DirectoryPartitionName` has changed.
 * xDnsServer:
   * OptIn to the following Dsc Resource Meta Tests:
     * Common Tests - Relative Path Length

--- a/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsRecord.Tests.ps1
@@ -24,6 +24,16 @@ try
 
     InModuleScope $script:DSCResourceName {
         #region Pester Test Initialization
+        $recordAData = New-CimInstance -Namespace root/Microsoft/Windows/DNS -ClassName DnsServerResourceRecordCnNme -ClientOnly -Property @{
+            IPv4Address = 'test.contoso.com'
+        }
+        $recordPtrData = New-CimInstance -Namespace root/Microsoft/Windows/DNS -ClassName DnsServerResourceRecordPTR -ClientOnly -Property @{
+            PtrDomainName = '192.168.0.1'
+        }
+        $recordCNameData = New-CimInstance -Namespace root/Microsoft/Windows/DNS -ClassName DnsServerResourceRecordA -ClientOnly -Property @{
+            HostNameAlias = '192.168.0.1'
+        }
+
         $dnsRecordsToTest = @(
             @{
                 TestParameters = @{
@@ -35,16 +45,12 @@ try
                     DnsServer  = 'localhost'
                     Ensure     = 'Present'
                 }
-                MockRecord     = @{
+                MockRecord     = New-CimInstance -Namespace root/Microsoft/Windows/DNS -ClassName DnsServerResourceRecord -ClientOnly -Property @{
                     HostName   = 'test'
                     RecordType = 'A'
                     DnsServer  = 'localhost'
                     TimeToLive = '01:00:00'
-                    RecordData = @{
-                        IPv4Address = @{
-                            IPAddressToString = '192.168.0.1'
-                        }
-                    }
+                    RecordData = $recordAData
                 }
             }
             @{
@@ -57,14 +63,12 @@ try
                     DnsServer  = 'localhost'
                     Ensure     = 'Present'
                 }
-                MockRecord     = @{
+                MockRecord     = New-CimInstance -Namespace root/Microsoft/Windows/DNS -ClassName DnsServerResourceRecord -ClientOnly -Property @{
                     HostName   = 'test'
                     RecordType = 'PTR'
                     DnsServer  = 'localhost'
                     TimeToLive = '01:00:00'
-                    RecordData = @{
-                        PtrDomainName = '192.168.0.1'
-                    }
+                    RecordData = $recordPtrData
                 }
             }
             @{
@@ -77,14 +81,12 @@ try
                     DnsServer  = 'localhost'
                     Ensure     = 'Present'
                 }
-                MockRecord     = @{
+                MockRecord     = New-CimInstance -Namespace root/Microsoft/Windows/DNS -ClassName DnsServerResourceRecord -ClientOnly -Property @{
                     HostName   = 'test'
                     RecordType = 'Cname'
                     DnsServer  = 'localhost'
                     TimeToLive = '01:00:00'
-                    RecordData = @{
-                        HostNameAlias = 'test.contoso.com'
-                    }
+                    RecordData = $recordCNameData
                 }
             }
         )
@@ -238,7 +240,6 @@ try
                     It "Should Call Set-DnsServerResourceRecord when the TTL does not match" {
                         Mock -CommandName Set-DnsServerResourceRecord
                         Mock -CommandName Get-DnsServerResourceRecord -MockWith { return $dnsRecord.MockRecord }
-
                         Set-TargetResource @presentParameters
                         Assert-MockCalled Get-DnsServerResourceRecord -Scope It
                         Assert-MockCalled Set-DnsServerResourceRecord -Scope It

--- a/Tests/Unit/Stubs/DnsServer.psm1
+++ b/Tests/Unit/Stubs/DnsServer.psm1
@@ -10341,15 +10341,13 @@ function Set-DnsServerResourceRecord {
         [Parameter(ParameterSetName='Set0', Mandatory=$true, Position=3, ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNullOrEmpty()]
         [ValidateNotNull()]
-        [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#DnsServerResourceRecord')]
-        [ciminstance]
+        [string]
         ${NewInputObject},
 
         [Parameter(ParameterSetName='Set0', Mandatory=$true, Position=2, ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNullOrEmpty()]
         [ValidateNotNull()]
-        [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#DnsServerResourceRecord')]
-        [ciminstance]
+        [string]
         ${OldInputObject},
 
         [Parameter(ParameterSetName='Set0')]

--- a/Tests/Unit/Stubs/DnsServer.psm1
+++ b/Tests/Unit/Stubs/DnsServer.psm1
@@ -10341,13 +10341,13 @@ function Set-DnsServerResourceRecord {
         [Parameter(ParameterSetName='Set0', Mandatory=$true, Position=3, ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNullOrEmpty()]
         [ValidateNotNull()]
-        [string]
+        [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#DnsServerResourceRecord')]
         ${NewInputObject},
 
         [Parameter(ParameterSetName='Set0', Mandatory=$true, Position=2, ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNullOrEmpty()]
         [ValidateNotNull()]
-        [string]
+        [PSTypeName('Microsoft.Management.Infrastructure.CimInstance#DnsServerResourceRecord')]
         ${OldInputObject},
 
         [Parameter(ParameterSetName='Set0')]


### PR DESCRIPTION
#### Pull Request (PR) description
This adds the following:
- Parameter to add a TTL to records created
- Created en-us and adds helper to call localized data
- Updated stub to not require ciminstance for Set-DnsServerResourceRecord
- Added tests for new parameter
- Added missing tests for Cname

#### This Pull Request (PR) fixes the following issues
- Fixes #67 


#### Task list
- [X] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [X] Resource documentation added/updated in README.md.
- [X] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [X] Comment-based help added/updated.
- [X] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [N/A] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [X] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdnsserver/108)
<!-- Reviewable:end -->
