### PR TITLE
xDnsServer: Resolve style guideline violations for hashtables

### DIFF
--- a/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
+++ b/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.psm1
@@ -156,7 +156,11 @@ function Set-TargetResource
         $Ensure = 'Present'
     )
 
-    $DNSParameters = @{ Name = $Name; ZoneName = $Zone; ComputerName = $DnsServer; } 
+    $DNSParameters = @{
+        Name         = $Name
+        ZoneName     = $Zone
+        ComputerName = $DnsServer
+    }
 
     if ($Ensure -eq 'Present')
     {

--- a/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.psm1
+++ b/DSCResources/MSFT_xDnsServerADZone/MSFT_xDnsServerADZone.psm1
@@ -250,12 +250,16 @@ function Set-TargetResource
             ## Update the existing zone
             if ($targetResource.DynamicUpdate -ne $DynamicUpdate)
             {
-                $params += @{DynamicUpdate = $DynamicUpdate}
+                $params += @{
+                    DynamicUpdate = $DynamicUpdate
+                }
                 Write-Verbose ($LocalizedData.SetPropertyMessage -f 'DynamicUpdate')
             }
             if ($targetResource.ReplicationScope -ne $ReplicationScope)
             {
-                $params += @{ReplicationScope = $ReplicationScope}
+                $params += @{
+                    ReplicationScope = $ReplicationScope
+                }
                 Write-Verbose ($LocalizedData.SetPropertyMessage -f 'ReplicationScope')
             }
             if ($DirectoryPartitionName -and $targetResource.DirectoryPartitionName -ne $DirectoryPartitionName)
@@ -273,9 +277,13 @@ function Set-TargetResource
                 # ReplicationScope is a required parameter if DirectoryPartitionName is specified
                 if ($params.keys -notcontains 'ReplicationScope')
                 {
-                    $params += @{ReplicationScope = $ReplicationScope }
+                    $params += @{
+                        ReplicationScope = $ReplicationScope
+                    }
                 }
-                $params += @{DirectoryPartitionName = $DirectoryPartitionName }
+                $params += @{
+                    DirectoryPartitionName = $DirectoryPartitionName
+                }
                 Write-Verbose ($LocalizedData.SetPropertyMessage -f 'DirectoryPartitionName')
             }
             Set-DnsServerPrimaryZone @params

--- a/DSCResources/MSFT_xDnsServerClientSubnet/MSFT_xDnsServerClientSubnet.psm1
+++ b/DSCResources/MSFT_xDnsServerClientSubnet/MSFT_xDnsServerClientSubnet.psm1
@@ -95,7 +95,9 @@ function Set-TargetResource
         $Ensure = 'Present'
     )
 
-    $dnsServerClientSubnetParameters = @{ Name = $Name}
+    $dnsServerClientSubnetParameters = @{
+        Name = $Name
+    }
     $clientSubnet = Get-DnsServerClientSubnet -Name $Name -ErrorAction SilentlyContinue
     if ($Ensure -eq 'Present')
     {

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ Requires Windows Server 2016 onwards
 
 ### Unreleased
 
+* Changes to xDnsServer
+  * Resolve style guideline violations for hashtables
+
 ### 1.16.0.0
 
 * Changes to XDnsServerADZone


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes several style guideline violations for hashtables in the following resource files:

- xDnsRecord
- xDnsServerAdZone
- xDnsServerClientSubnet

These are currently causing the Appveyor tests to fail.

#### This Pull Request (PR) fixes the following issues

None

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
