### PR TITLE
xDnsServerForwarder: Allow the removal of DNS forwarders by using an empty collection…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,5 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Fix EnableLogFileRollover Parameter name in README.
 - xDnsRecord
   - Fix "Removing a DNS A Record" example.
+- xDnsServerForwarder
+  - Fix "Set-DnsServerForwarder" where IPAddress collection is null or empty

--- a/source/DSCResources/MSFT_xDnsServerForwarder/en-US/MSFT_xDnsServerForwarder.strings.psd1
+++ b/source/DSCResources/MSFT_xDnsServerForwarder/en-US/MSFT_xDnsServerForwarder.strings.psd1
@@ -2,5 +2,6 @@
 ConvertFrom-StringData @'
     GettingDnsForwardersMessage  = Getting current DNS forwarders.
     SettingDnsForwardersMessage  = Setting DNS forwarders.
+    DeletingDnsForwardersMessage  = Deleting DNS forwarders.
     ValidatingIPAddressesMessage = Validate IP addresses.
 '@


### PR DESCRIPTION
#### Pull Request (PR) description
xDNSServerForwarder fails if IPAddresses is an empty collection as in the examples found in this repo. The error seen on the target machine is
``` 
_Cannot validate argument on parameter 
'IPAddress'. The argument is null, empty, or an element of the argument 
collection contains a null value. Supply a collection that does not contain any
 null values and then try the command again._
```
#### This Pull Request (PR) fixes the following issues
It fixes the above issue by allowing the user to specify an empty collection. It is assumed that this 'blank' state means to remove any existing forwarders using a different set of cmdlets.

Furthermore, should the user only want to apply UseRooHints this is catered for by only adding the required parameters to the Set-DnsServerForwarder cmdlet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/126)
<!-- Reviewable:end -->
