### PR TITLE
xDnsRecord: Adding credential so that DNS record could be added from a remote computer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md).
 
 ## [Unreleased]
+-xDnsServer
+ -Added credential to allow DNS records to be added by an authorised account from a remote computer. This is not a breaking change
 
 ### Added
 

--- a/source/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
+++ b/source/DSCResources/MSFT_xDnsRecord/MSFT_xDnsRecord.schema.mof
@@ -7,5 +7,6 @@ class MSFT_xDnsRecord : OMI_BaseResource
     [Key, Description("Specifies the Target Hostname or IP Address.")] string Target;
     [Write, Description("Name of the DnsServer to create the record on.")] string DnsServer;
     [Write, Description("Should this DNS resource record be present or absent"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Credential used to set record"), EmbeddedInstance("MSFT_Credential")] String Credential;
 };
 


### PR DESCRIPTION
#### Pull Request (PR) description
Adding a PS Credential object with permissions to add a DNS record when this resource is executed from a remote computer. This is not a breaking change.


- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/127)
<!-- Reviewable:end -->
