### PR TITLE
BREAKING CHANGE: xDnsServerDiagnostics: Add parameter DnsServer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     parameter `DnsServer`. This prevents the resource from being used twice
     in the same configuration using the same value for the parameter `DnsServer`
     ([issue #156](https://github.com/dsccommunity/xDnsServer/issues/156)).
+- xDnsServerDiagnostics
+  - BREAKING CHANGE: The mandatory parameter was replaced by the mandatory
+    parameter `DnsServer`. This prevents the resource from being used twice
+    in the same configuration using the same value for the parameter `DnsServer`
+    ([issue #157](https://github.com/dsccommunity/xDnsServer/issues/157)).
 
 ### Removed
 

--- a/source/DSCResources/MSFT_xDnsServerDiagnostics/MSFT_xDnsServerDiagnostics.schema.mof
+++ b/source/DSCResources/MSFT_xDnsServerDiagnostics/MSFT_xDnsServerDiagnostics.schema.mof
@@ -1,7 +1,7 @@
 [ClassVersion("1.0.0.0"), FriendlyName("xDnsServerDiagnostics")]
 class MSFT_xDnsServerDiagnostics : OMI_BaseResource
 {
-    [Key, Description("Key for the resource.  It doesn't matter what it is as long as it's unique within the configuration.")] String Name;
+    [Key, Description("Specifies the DNS server to connect to, or use 'localhost' for the current node.")] String DnsServer;
     [Write, Description("Specifies whether to enable the logging of DNS responses.")] Boolean Answers;
     [Write, Description("Specifies whether to enable log file rollover.")] Boolean EnableLogFileRollover;
     [Write, Description("Specifies whether the DNS server logs local lookup events.")] Boolean EnableLoggingForLocalLookupEvent;

--- a/source/DSCResources/MSFT_xDnsServerDiagnostics/README.md
+++ b/source/DSCResources/MSFT_xDnsServerDiagnostics/README.md
@@ -1,3 +1,12 @@
 # Description
 
-The xDnsServerDiagnostics DSC resource manages the debugging and logging paramters on a Domain Name System (DNS) server.
+The xDnsServerDiagnostics DSC resource manages the debugging and logging
+parameters on a Domain Name System (DNS) server.
+
+If the parameter **DnsServer** is set to `'localhost'` then the resource
+can normally use the default credentials (SYSTEM) to configure the DNS server
+settings. If using any other value for the parameter **DnsServer** make sure
+that the credential the resource is run as have the correct permissions
+at the target node and the necessary network traffic is permitted.
+It is possible to run the resource with specific credentials using the
+built-in parameter **PsDscRunAsCredential**.

--- a/source/Examples/Resources/xDnsServerDiagnostics/1-xDnsServerDiagnostics_CurrentNode_Config.ps1
+++ b/source/Examples/Resources/xDnsServerDiagnostics/1-xDnsServerDiagnostics_CurrentNode_Config.ps1
@@ -1,0 +1,81 @@
+<#PSScriptInfo
+
+.VERSION 1.0.1
+
+.GUID 5078427f-0fae-40a6-af63-2601a96a832c
+
+.AUTHOR DSC Community
+
+.COMPANYNAME DSC Community
+
+.COPYRIGHT DSC Community contributors. All rights reserved.
+
+.TAGS DSCConfiguration
+
+.LICENSEURI https://github.com/dsccommunity/xDnsServer/blob/main/LICENSE
+
+.PROJECTURI https://github.com/dsccommunity/xDnsServer
+
+.ICONURI https://dsccommunity.org/images/DSC_Logo_300p.png
+
+.EXTERNALMODULEDEPENDENCIES
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+Updated author, copyright notice, and URLs.
+
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+
+#>
+
+#Requires -Module xDnsServer
+
+
+<#
+    .DESCRIPTION
+        This configuration will manage a DNS server's diagnostics settings
+#>
+
+Configuration xDnsServerDiagnostics_config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    Node localhost
+    {
+        xDnsServerDiagnostics 'Diagnostics'
+        {
+            DnsServer                            = 'localhost'
+            Answers                              = $true
+            EnableLogFileRollover                = $true
+            EnableLoggingForLocalLookupEvent     = $true
+            EnableLoggingForPluginDllEvent       = $true
+            EnableLoggingForRecursiveLookupEvent = $true
+            EnableLoggingForRemoteServerEvent    = $true
+            EnableLoggingForServerStartStopEvent = $true
+            EnableLoggingForTombstoneEvent       = $true
+            EnableLoggingForZoneDataWriteEvent   = $true
+            EnableLoggingForZoneLoadingEvent     = $true
+            EnableLoggingToFile                  = $true
+            EventLogLevel                        = 7
+            FilterIPAddressList                  = @('10.0.10.1', '10.0.10.2')
+            FullPackets                          = $false
+            LogFilePath                          = 'd:\dnslogs\dns.log'
+            MaxMBFileSize                        = 500000000
+            Notifications                        = $true
+            Queries                              = $true
+            QuestionTransactions                 = $true
+            ReceivePackets                       = $false
+            SaveLogsToPersistentStorage          = $true
+            SendPackets                          = $false
+            TcpPackets                           = $false
+            UdpPackets                           = $false
+            UnmatchedResponse                    = $false
+            Update                               = $true
+            UseSystemEventLog                    = $true
+            WriteThrough                         = $true
+        }
+    }
+}

--- a/source/Examples/Resources/xDnsServerDiagnostics/1-xDnsServerDiagnostics_CurrentNode_Config.ps1
+++ b/source/Examples/Resources/xDnsServerDiagnostics/1-xDnsServerDiagnostics_CurrentNode_Config.ps1
@@ -39,7 +39,7 @@ Updated author, copyright notice, and URLs.
         This configuration will manage a DNS server's diagnostics settings
 #>
 
-Configuration xDnsServerDiagnostics_config
+Configuration xDnsServerDiagnostics_CurrentNode_Config
 {
     Import-DscResource -ModuleName 'xDnsServer'
 

--- a/source/Examples/Resources/xDnsServerDiagnostics/2-xDnsServerDiagnostics_RemoteNode_Config.ps1
+++ b/source/Examples/Resources/xDnsServerDiagnostics/2-xDnsServerDiagnostics_RemoteNode_Config.ps1
@@ -2,7 +2,7 @@
 
 .VERSION 1.0.1
 
-.GUID 5078427f-0fae-40a6-af63-2601a96a832c
+.GUID 6b886caa-43ec-4a39-a9d5-84d819c5192b
 
 .AUTHOR DSC Community
 
@@ -12,13 +12,13 @@
 
 .TAGS DSCConfiguration
 
-.LICENSEURI https://github.com/dsccommunity/xDnsServer/blob/master/LICENSE
+.LICENSEURI https://github.com/dsccommunity/xDnsServer/blob/main/LICENSE
 
 .PROJECTURI https://github.com/dsccommunity/xDnsServer
 
 .ICONURI https://dsccommunity.org/images/DSC_Logo_300p.png
 
-.EXTERNALMODULEDEPENDENCIES 
+.EXTERNALMODULEDEPENDENCIES
 
 .REQUIREDSCRIPTS
 
@@ -29,7 +29,7 @@ Updated author, copyright notice, and URLs.
 
 .PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
 
-#> 
+#>
 
 #Requires -Module xDnsServer
 
@@ -39,7 +39,7 @@ Updated author, copyright notice, and URLs.
         This configuration will manage a DNS server's diagnostics settings
 #>
 
-Configuration xDnsServerDiagnostics_config
+Configuration DnsServerDiagnostics_RemoteNode_Config
 {
     Import-DscResource -ModuleName 'xDnsServer'
 
@@ -47,7 +47,7 @@ Configuration xDnsServerDiagnostics_config
     {
         xDnsServerDiagnostics 'Diagnostics'
         {
-            Name                                 = 'Diagnostics'
+            DnsServer                            = 'dns1.company.local'
             Answers                              = $true
             EnableLogFileRollover                = $true
             EnableLoggingForLocalLookupEvent     = $true

--- a/source/Examples/Resources/xDnsServerDiagnostics/2-xDnsServerDiagnostics_RemoteNode_Config.ps1
+++ b/source/Examples/Resources/xDnsServerDiagnostics/2-xDnsServerDiagnostics_RemoteNode_Config.ps1
@@ -39,7 +39,7 @@ Updated author, copyright notice, and URLs.
         This configuration will manage a DNS server's diagnostics settings
 #>
 
-Configuration DnsServerDiagnostics_RemoteNode_Config
+Configuration xDnsServerDiagnostics_RemoteNode_Config
 {
     Import-DscResource -ModuleName 'xDnsServer'
 

--- a/tests/Integration/MSFT_xDnsServerDiagnostics.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerDiagnostics.Integration.Tests.ps1
@@ -64,7 +64,7 @@ try
                     -and $_.ResourceId -eq $resourceId
                 }
 
-                $resourceCurrentState.Name                                 | Should -Be $ConfigurationData.AllNodes.Name
+                $resourceCurrentState.DnsServer                            | Should -Be $ConfigurationData.AllNodes.DnsServer
                 $resourceCurrentState.Answers                              | Should -Be $ConfigurationData.AllNodes.Answers
                 $resourceCurrentState.EnableLogFileRollover                | Should -Be $ConfigurationData.AllNodes.EnableLogFileRollover
                 $resourceCurrentState.EnableLoggingForLocalLookupEvent     | Should -Be $ConfigurationData.AllNodes.EnableLoggingForLocalLookupEvent

--- a/tests/Integration/MSFT_xDnsServerDiagnostics.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerDiagnostics.config.ps1
@@ -4,7 +4,7 @@ $ConfigurationData = @{
             NodeName                             = 'localhost'
             CertificateFile                      = $env:DscPublicCertificatePath
 
-            Name                                 = 'xDnsServerDiagnostics_Integration'
+            DnsServer                            = 'localhost'
             Answers                              = $true
             EnableLogFileRollover                = $true
             EnableLoggingForLocalLookupEvent     = $true
@@ -45,7 +45,7 @@ configuration MSFT_xDnsServerDiagnostics_SetDiagnostics_Config
     {
         xDnsServerDiagnostics 'Integration_Test'
         {
-            Name                                 = $Node.Name
+            DnsServer                            = $Node.DnsServer
             Answers                              = $Node.Answers
             EnableLogFileRollover                = $Node.EnableLogFileRollover
             EnableLoggingForLocalLookupEvent     = $Node.EnableLoggingForLocalLookupEvent

--- a/tests/Unit/MSFT_xDnsServerDiagnostics.Tests.ps1
+++ b/tests/Unit/MSFT_xDnsServerDiagnostics.Tests.ps1
@@ -32,8 +32,8 @@ try
 {
     InModuleScope $script:dscResourceName {
         #region Pester Test Initialization
-        $testParameters = [PSCustomObject]@{
-            Name                                 = 'xDnsServerDiagnostics_Integration'
+        $testParameters = @{
+            DnsServer                            = 'dns1.company.local'
             Answers                              = $true
             EnableLogFileRollover                = $true
             EnableLoggingForLocalLookupEvent     = $true
@@ -64,36 +64,36 @@ try
             WriteThrough                         = $true
         }
 
-        $mockGetDnsServerDiagnostics = [PSCustomObject]@{
-            Name                                 = 'xDnsServerDiagnostics_Integration'
-            Answers                              = $true
-            EnableLogFileRollover                = $true
-            EnableLoggingForLocalLookupEvent     = $true
-            EnableLoggingForPluginDllEvent       = $true
-            EnableLoggingForRecursiveLookupEvent = $true
-            EnableLoggingForRemoteServerEvent    = $true
-            EnableLoggingForServerStartStopEvent = $true
-            EnableLoggingForTombstoneEvent       = $true
-            EnableLoggingForZoneDataWriteEvent   = $true
-            EnableLoggingForZoneLoadingEvent     = $true
-            EnableLoggingToFile                  = $true
-            EventLogLevel                        = 4
-            FilterIPAddressList                  = "192.168.1.1","192.168.1.2"
-            FullPackets                          = $true
-            LogFilePath                          = 'C:\Windows\System32\DNS\DNSDiagnostics.log'
-            MaxMBFileSize                        = 500000000
-            Notifications                        = $true
-            Queries                              = $true
-            QuestionTransactions                 = $true
-            ReceivePackets                       = $true
-            SaveLogsToPersistentStorage          = $true
-            SendPackets                          = $true
-            TcpPackets                           = $true
-            UdpPackets                           = $true
-            UnmatchedResponse                    = $true
-            Update                               = $true
-            UseSystemEventLog                    = $true
-            WriteThrough                         = $true
+        $mockGetDnsServerDiagnostics = @{
+            DnsServer                            = 'dns1.company.local'
+            Answers                              = $false
+            EnableLogFileRollover                = $false
+            EnableLoggingForLocalLookupEvent     = $false
+            EnableLoggingForPluginDllEvent       = $false
+            EnableLoggingForRecursiveLookupEvent = $false
+            EnableLoggingForRemoteServerEvent    = $false
+            EnableLoggingForServerStartStopEvent = $false
+            EnableLoggingForTombstoneEvent       = $false
+            EnableLoggingForZoneDataWriteEvent   = $false
+            EnableLoggingForZoneLoadingEvent     = $false
+            EnableLoggingToFile                  = $false
+            EventLogLevel                        = 3
+            FilterIPAddressList                  = "192.168.1.3","192.168.1.4"
+            FullPackets                          = $false
+            LogFilePath                          = 'C:\Windows\System32\DNS_log\DNSDiagnostics.log'
+            MaxMBFileSize                        = 400000000
+            Notifications                        = $false
+            Queries                              = $false
+            QuestionTransactions                 = $false
+            ReceivePackets                       = $false
+            SaveLogsToPersistentStorage          = $false
+            SendPackets                          = $false
+            TcpPackets                           = $false
+            UdpPackets                           = $false
+            UnmatchedResponse                    = $false
+            Update                               = $false
+            UseSystemEventLog                    = $false
+            WriteThrough                         = $false
         }
 
         $commonParameters += [System.Management.Automation.PSCmdlet]::CommonParameters
@@ -114,7 +114,7 @@ try
             WhatIf              = $true
             Confirm             = $true
             UseTransaction      = $true
-            Name                = 'DnsServerDiagnostic'
+            DnsServer           = 'dns1.company.local'
         }
         #endregion Pester Test Initialization
 
@@ -125,11 +125,12 @@ try
             Context 'Get-TargetResource' {
                 It "Get method returns 'something'" {
                     Mock -CommandName Get-DnsServerDiagnostics -MockWith {$mockGetDnsServerDiagnostics}
-                    $getResult = Get-TargetResource -Name 'DnsServerDiagnostic'
+
+                    $getResult = Get-TargetResource -DnsServer 'dns1.company.local'
 
                     foreach ($key in $getResult.Keys)
                     {
-                        if ($null -ne $getResult[$key] -and $key -ne 'Name')
+                        if ($null -ne $getResult[$key] -and $key -ne 'DnsServer')
                         {
                             $getResult[$key] | Should be $mockGetDnsServerDiagnostics.$key
                         }
@@ -139,22 +140,26 @@ try
                 It 'Get throws when DnsServerDiagnostics is not found' {
                     Mock -CommandName Get-DnsServerDiagnostics -MockWith {throw 'Invalid Class'}
 
-                    {Get-TargetResource -Name 'DnsServerDiagnostics'} | should throw 'Invalid Class'
+                    {Get-TargetResource -DnsServer 'dns1.company.local'} | Should -Throw 'Invalid Class'
                 }
             }
 
             Context 'Test-TargetResource' {
-                $falseParameters = @{Name = 'DnsServerDiagnostic'}
+                $falseParameters = @{
+                    DnsServer = 'dns1.company.local'
+                }
 
                 foreach ($key in $testParameters.Keys)
                 {
-                    if ($key -ne 'Name')
+                    if ($key -ne 'DnsServer')
                     {
                         $falseTestParameters = $falseParameters.Clone()
                         $falseTestParameters.Add($key,$testParameters[$key])
+
                         It "Test method returns false when testing $key" {
                             Mock -CommandName Get-TargetResource -MockWith {$mockGetDnsServerDiagnostics}
-                            Test-TargetResource @falseTestParameters | Should be $false
+
+                            Test-TargetResource @falseTestParameters | Should -BeFalse
                         }
                     }
                 }
@@ -164,14 +169,14 @@ try
                 It 'Test throws when DnsServerDiagnostics is not found' {
                     Mock -CommandName Get-DnsServerDiagnostics -MockWith {throw 'Invalid Class'}
 
-                    {Get-TargetResource -Name 'xDnsServerSetting_Integration'} | should throw 'Invalid Class'
+                    {Get-TargetResource -DnsServer 'dns1.company.local'} | Should -Throw 'Invalid Class'
                 }
             }
 
             Context 'Set-TargetResource' {
                 It 'Set method calls Set-CimInstance' {
                     Mock -CommandName Get-DnsServerDiagnostics -MockWith {$mockGetDnsServerDiagnostics}
-                    Mock -CommandName Set-DnsServerDiagnostics {}
+                    Mock -CommandName Set-DnsServerDiagnostics
 
                     Set-TargetResource @testParameters
 
@@ -183,16 +188,16 @@ try
 
         #region Example state 2
         Describe 'The system is in the desired state' {
-
             Context 'Test-TargetResource' {
-
                 Mock -CommandName Get-TargetResource -MockWith { $mockGetDnsServerDiagnostics }
 
-                $trueParameters = @{ Name = 'xDnsServerDiagnostics_Integration' }
+                $trueParameters = @{
+                    DnsServer = 'dns1.company.local'
+                }
 
                 foreach ($key in $testParameters.Keys)
                 {
-                    if ($key -ne 'Name')
+                    if ($key -ne 'DnsServer')
                     {
                         $trueTestParameters = $trueParameters.Clone()
 
@@ -200,7 +205,7 @@ try
 
                         It "Test method returns true when testing $key" {
                             $result = Test-TargetResource @trueTestParameters
-                            $result | Should be $true
+                            $result | Should -BeTrue
                         }
                     }
                 }
@@ -218,7 +223,7 @@ try
 
                     foreach ($key in $removeResults.Keys)
                     {
-                        $commonParameters -notcontains $key | should be $true
+                        $commonParameters -notcontains $key | Should -BeTrue
                     }
                 }
             }


### PR DESCRIPTION

#### Pull Request (PR) description
- xDnsServerDiagnostics
  - BREAKING CHANGE: The mandatory parameter was replaced by the mandatory
    parameter `DnsServer`. This prevents the resource from being used twice in the
    same configuration using the same value for the parameter `DnsServer` (issue #157).

#### This Pull Request (PR) fixes the following issues

- Fixes #157

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/162)
<!-- Reviewable:end -->
