### PR TITLE
xDnsServerRootHint: Added integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added more examples.
 - xDnsRecordMx
   - Added new resource to manage MX records
+- xDnsServerRootHint
+  - Added integration test ([issue #174](https://github.com/dsccommunity/xDnsServer/issues/174)).
 
 ### Changed
 
@@ -100,6 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xDnsServerAdZone
   - Now the parameter `ComputerName` can be used without throwing an exception
     ([issue 79](https://github.com/PowerShell/xDnsServer/issues/79)).
+- xDnsServerRootHint
+  - Fixed the verbose message returning the correct number of root hints.
 
 ## [1.16.0.0] - 2019-10-30
 

--- a/source/DSCResources/MSFT_xDnsServerRootHint/MSFT_xDnsServerRootHint.psm1
+++ b/source/DSCResources/MSFT_xDnsServerRootHint/MSFT_xDnsServerRootHint.psm1
@@ -40,7 +40,7 @@ function Get-TargetResource
         NameServer       = Convert-RootHintsToHashtable -RootHints @(Get-DnsServerRootHint)
     }
 
-    Write-Verbose -Message ($script:localizedData.FoundRootHintsMessage -f $result.Count)
+    Write-Verbose -Message ($script:localizedData.FoundRootHintsMessage -f $result.NameServer.Count)
     $result
 }
 

--- a/tests/Integration/MSFT_xDnsServerRootHint.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerRootHint.Integration.Tests.ps1
@@ -1,0 +1,152 @@
+$script:dscModuleName   = 'xDnsServer'
+$script:dscResourceFriendlyName = 'xDnsServerRootHint'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+
+try
+{
+    Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+}
+catch [System.IO.FileNotFoundException]
+{
+    throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+}
+
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -ResourceType 'Mof' `
+    -TestType 'Integration'
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_RemoveAllRootHints_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsSingleInstance | Should -Be 'Yes'
+                $resourceCurrentState.NameServer       | Should -BeNullOrEmpty
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_SetRootHints_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $nameServerHashtable = @{}
+
+                foreach ($nameServer in $resourceCurrentState.NameServer)
+                {
+                    $nameServerHashtable.Add($nameServer.Key, $nameServer.Value)
+                }
+
+                $nameServerHashtable.Count | Should -Be $ConfigurationData.AllNodes.NameServer.Count
+
+                $resourceCurrentState.IsSingleInstance | Should -Be 'Yes'
+
+                $nameServerHashtable['H.ROOT-SERVERS.NET.'] | Should -Be '198.97.190.53'
+                $nameServerHashtable['E.ROOT-SERVERS.NET.'] | Should -Be '192.203.230.10'
+                $nameServerHashtable['M.ROOT-SERVERS.NET.'] | Should -Be '202.12.27.33'
+                $nameServerHashtable['A.ROOT-SERVERS.NET.'] | Should -Be '198.41.0.4'
+                $nameServerHashtable['D.ROOT-SERVERS.NET.'] | Should -Be '199.7.91.13'
+                $nameServerHashtable['F.ROOT-SERVERS.NET.'] | Should -Be '192.5.5.241'
+                $nameServerHashtable['B.ROOT-SERVERS.NET.'] | Should -Be '192.228.79.201'
+                $nameServerHashtable['G.ROOT-SERVERS.NET.'] | Should -Be '192.112.36.4'
+                $nameServerHashtable['C.ROOT-SERVERS.NET.'] | Should -Be '192.33.4.12'
+                $nameServerHashtable['K.ROOT-SERVERS.NET.'] | Should -Be '193.0.14.129'
+                $nameServerHashtable['I.ROOT-SERVERS.NET.'] | Should -Be '192.36.148.17'
+                $nameServerHashtable['J.ROOT-SERVERS.NET.'] | Should -Be '192.58.128.30'
+                $nameServerHashtable['L.ROOT-SERVERS.NET.'] | Should -Be '199.7.83.42'
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+    }
+}
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}

--- a/tests/Integration/MSFT_xDnsServerRootHint.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerRootHint.config.ps1
@@ -1,0 +1,52 @@
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName        = 'localhost'
+            CertificateFile = $env:DscPublicCertificatePath
+
+            NameServer      = @{
+                'H.ROOT-SERVERS.NET.' = '198.97.190.53'
+                'E.ROOT-SERVERS.NET.' = '192.203.230.10'
+                'M.ROOT-SERVERS.NET.' = '202.12.27.33'
+                'A.ROOT-SERVERS.NET.' = '198.41.0.4'
+                'D.ROOT-SERVERS.NET.' = '199.7.91.13'
+                'F.ROOT-SERVERS.NET.' = '192.5.5.241'
+                'B.ROOT-SERVERS.NET.' = '192.228.79.201'
+                'G.ROOT-SERVERS.NET.' = '192.112.36.4'
+                'C.ROOT-SERVERS.NET.' = '192.33.4.12'
+                'K.ROOT-SERVERS.NET.' = '193.0.14.129'
+                'I.ROOT-SERVERS.NET.' = '192.36.148.17'
+                'J.ROOT-SERVERS.NET.' = '192.58.128.30'
+                'L.ROOT-SERVERS.NET.' = '199.7.83.42'
+            }
+        }
+    )
+}
+
+configuration MSFT_xDnsServerRootHint_RemoveAllRootHints_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerDiagnostics 'Integration_Test'
+        {
+            IsSingleInstance = 'Yes'
+            NameServer       = @{}
+        }
+    }
+}
+
+configuration MSFT_xDnsServerRootHint_SetRootHints_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerDiagnostics 'Integration_Test'
+        {
+            IsSingleInstance = 'Yes'
+            NameServer       = $Node.NameServer
+        }
+    }
+}

--- a/tests/Integration/MSFT_xDnsServerRootHint.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerRootHint.config.ps1
@@ -29,7 +29,7 @@ configuration MSFT_xDnsServerRootHint_RemoveAllRootHints_Config
 
     node $AllNodes.NodeName
     {
-        xDnsServerDiagnostics 'Integration_Test'
+        xDnsServerRootHint 'Integration_Test'
         {
             IsSingleInstance = 'Yes'
             NameServer       = @{}
@@ -43,7 +43,7 @@ configuration MSFT_xDnsServerRootHint_SetRootHints_Config
 
     node $AllNodes.NodeName
     {
-        xDnsServerDiagnostics 'Integration_Test'
+        xDnsServerRootHint 'Integration_Test'
         {
             IsSingleInstance = 'Yes'
             NameServer       = $Node.NameServer


### PR DESCRIPTION

#### Pull Request (PR) description
- xDnsServerRootHint
  - Added integration test (issue #174)
  - Fixed the verbose message returning the correct number of root hints.
 
#### This Pull Request (PR) fixes the following issues

- Fixes #174

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/183)
<!-- Reviewable:end -->
