### PR TITLE
xDnsServerForwarder: Add integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xDnsServerPrimaryZone
   - Now the property `Name` is always returned from `Get-TargetResource`
     since it is a `Key` property.
+- xDnsServerForwarder
+  - When providing an empty collection the resource will enforce that no
+    forwarders are present.
 
 ### Removed
 
@@ -102,6 +105,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xDnsServerAdZone
   - Now the parameter `ComputerName` can be used without throwing an exception
     ([issue 79](https://github.com/PowerShell/xDnsServer/issues/79)).
+- xDnsServerForwarder
+  - Now it is possible to just enforce the property `UseRooHint` without
+    changing forwarders.
 
 ## [1.16.0.0] - 2019-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added more examples.
 - xDnsRecordMx
   - Added new resource to manage MX records
+- xDnsServerForwarder
+  - Added integration test ([issue #170](https://github.com/dsccommunity/xDnsServer/issues/170)).
 
 ### Changed
 

--- a/source/DSCResources/MSFT_xDnsServerForwarder/en-US/MSFT_xDnsServerForwarder.strings.psd1
+++ b/source/DSCResources/MSFT_xDnsServerForwarder/en-US/MSFT_xDnsServerForwarder.strings.psd1
@@ -3,4 +3,6 @@ ConvertFrom-StringData @'
     GettingDnsForwardersMessage  = Getting current DNS forwarders.
     SettingDnsForwardersMessage  = Setting DNS forwarders.
     ValidatingIPAddressesMessage = Validate IP addresses.
+    DeletingDnsForwardersMessage = Deleting DNS forwarders.
+    SettingUseRootHintProperty   = Setting the use root hint property to {0}.
 '@

--- a/source/Examples/Resources/xDnsServerForwarder/3-xDnsServerForwarder_SetUseRootHint_Config.ps1
+++ b/source/Examples/Resources/xDnsServerForwarder/3-xDnsServerForwarder_SetUseRootHint_Config.ps1
@@ -1,0 +1,54 @@
+<#PSScriptInfo
+
+.VERSION 1.0.0
+
+.GUID 253542b-7448-4379-8272-fed7babe5e1d
+
+.AUTHOR DSC Community
+
+.COMPANYNAME DSC Community
+
+.COPYRIGHT DSC Community contributors. All rights reserved.
+
+.TAGS DSCConfiguration
+
+.LICENSEURI https://github.com/dsccommunity/xDnsServer/blob/main/LICENSE
+
+.PROJECTURI https://github.com/dsccommunity/xDnsServer
+
+.ICONURI https://dsccommunity.org/images/DSC_Logo_300p.png
+
+.EXTERNALMODULEDEPENDENCIES
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+Updated author, copyright notice, and URLs.
+
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+
+#>
+
+#Requires -Module xDnsServer
+
+
+<#
+    .DESCRIPTION
+        This configuration will remove all the DNS forwarders
+#>
+
+Configuration xDnsServerForwarder_SetUseRootHint_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    Node localhost
+    {
+        xDnsServerForwarder 'SetUseRootHints'
+        {
+            IsSingleInstance = 'Yes'
+            UseRootHint      = $true
+        }
+    }
+}

--- a/source/Examples/Resources/xDnsServerForwarder/3-xDnsServerForwarder_SetUseRootHint_Config.ps1
+++ b/source/Examples/Resources/xDnsServerForwarder/3-xDnsServerForwarder_SetUseRootHint_Config.ps1
@@ -2,7 +2,7 @@
 
 .VERSION 1.0.0
 
-.GUID 253542b-7448-4379-8272-fed7babe5e1d
+.GUID 0253542b-7448-4379-8272-fed7babe5e1d
 
 .AUTHOR DSC Community
 

--- a/tests/Integration/MSFT_xDnsRecordMx.Integration.tests.ps1
+++ b/tests/Integration/MSFT_xDnsRecordMx.Integration.tests.ps1
@@ -91,7 +91,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be 'Present'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -150,7 +150,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be $shouldBeData.Ensure
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -209,7 +209,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be $shouldBeData.Ensure
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Integration/MSFT_xDnsRecordSrv.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsRecordSrv.Integration.Tests.ps1
@@ -94,7 +94,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be 'Present'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -158,7 +158,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be $shouldBeData.Ensure
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -224,7 +224,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be $shouldBeData.Ensure
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Integration/MSFT_xDnsServerClientSubnet.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerClientSubnet.Integration.Tests.ps1
@@ -70,7 +70,7 @@ try
                 $resourceCurrentState.IPv4Subnet | Should -Be '10.1.1.0/24'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -118,7 +118,7 @@ try
                 $resourceCurrentState.IPv4Subnet | Should -Be '10.1.2.0/24'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -167,7 +167,7 @@ try
                 $resourceCurrentState.IPv4Subnet | Should -Contain '10.1.2.0/24'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -215,7 +215,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be 'Absent'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -263,7 +263,7 @@ try
                 $resourceCurrentState.IPv6Subnet | Should -Be 'db8::1/28'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -311,7 +311,7 @@ try
                 $resourceCurrentState.IPv6Subnet | Should -Be '2001:db8::/32'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -360,7 +360,7 @@ try
                 $resourceCurrentState.IPv6Subnet | Should -Contain 'db8::1/28'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }
@@ -407,7 +407,7 @@ try
                 $resourceCurrentState.Ensure | Should -Be 'Absent'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -BeTrue
             }
         }

--- a/tests/Integration/MSFT_xDnsServerConditionalForwarder.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerConditionalForwarder.Integration.Tests.ps1
@@ -122,7 +122,7 @@ try
                 $resourceCurrentState.MasterServers | Should -Be $ConfigurationData.NonNodeData.MasterServers
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -173,7 +173,7 @@ try
                 $resourceCurrentState.MasterServers | Should -Be $ConfigurationData.NonNodeData.MasterServers
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -224,7 +224,7 @@ try
                 $resourceCurrentState.MasterServers | Should -Be $ConfigurationData.NonNodeData.MasterServers
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -275,7 +275,7 @@ try
                 $resourceCurrentState.MasterServers | Should -Be $ConfigurationData.NonNodeData.MasterServers
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -325,7 +325,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ZoneData.ZoneName
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -375,7 +375,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ZoneData.ZoneName
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -425,7 +425,7 @@ try
                 $resourceCurrentState.Name | Should -Be $ZoneData.ZoneName
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Integration/MSFT_xDnsServerDiagnostics.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerDiagnostics.Integration.Tests.ps1
@@ -95,7 +95,7 @@ try
                 $resourceCurrentState.WriteThrough                         | Should -Be $ConfigurationData.AllNodes.WriteThrough
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Integration/MSFT_xDnsServerForwarder.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerForwarder.Integration.Tests.ps1
@@ -1,0 +1,181 @@
+$script:dscModuleName   = 'xDnsServer'
+$script:dscResourceFriendlyName = 'xDnsServerForwarder'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+
+try
+{
+    Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+}
+catch [System.IO.FileNotFoundException]
+{
+    throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+}
+
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -ResourceType 'Mof' `
+    -TestType 'Integration'
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_SetForwarderDoNotUseRootHints_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsSingleInstance | Should -Be 'Yes'
+                $resourceCurrentState.IPAddresses      | Should -Be $ConfigurationData.AllNodes.ForwarderIpAddress
+                $resourceCurrentState.UseRootHint      | Should -BeFalse
+            }
+
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_SetForwarderUseRootHints_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsSingleInstance | Should -Be 'Yes'
+                $resourceCurrentState.IPAddresses      | Should -Be $ConfigurationData.AllNodes.ForwarderIpAddress
+                $resourceCurrentState.UseRootHint      | Should -BeTrue
+            }
+
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_RemoveForwarders_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsSingleInstance | Should -Be 'Yes'
+                $resourceCurrentState.IPAddresses      | Should -BeNullOrEmpty
+                $resourceCurrentState.UseRootHint      | Should -BeFalse
+            }
+
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+    }
+}
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}

--- a/tests/Integration/MSFT_xDnsServerForwarder.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerForwarder.Integration.Tests.ps1
@@ -173,6 +173,55 @@ try
         }
 
         Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_SetUseRootHint_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.IsSingleInstance | Should -Be 'Yes'
+                $resourceCurrentState.IPAddresses      | Should -BeNullOrEmpty
+                $resourceCurrentState.UseRootHint      | Should -BeTrue
+            }
+
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
     }
 }
 finally

--- a/tests/Integration/MSFT_xDnsServerForwarder.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerForwarder.config.ps1
@@ -1,0 +1,55 @@
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName           = 'localhost'
+            CertificateFile    = $env:DscPublicCertificatePath
+
+            ForwarderIpAddress = @('192.168.0.10', '192.168.0.11')
+        }
+    )
+}
+
+configuration MSFT_xDnsServerForwarder_SetForwarderDoNotUseRootHints_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerForwarder 'Integration_Test'
+        {
+            IsSingleInstance = 'Yes'
+            IPAddresses      = $Node.ForwarderIpAddress
+            UseRootHint      = $false
+        }
+    }
+}
+
+configuration MSFT_xDnsServerForwarder_SetForwarderUseRootHints_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerForwarder 'Integration_Test'
+        {
+            IsSingleInstance = 'Yes'
+            IPAddresses      = $Node.ForwarderIpAddress
+            UseRootHint      = $true
+        }
+    }
+}
+
+configuration MSFT_xDnsServerForwarder_RemoveForwarders_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerForwarder 'Integration_Test'
+        {
+            IsSingleInstance = 'Yes'
+            IPAddresses      = @()
+            UseRootHint      = $false
+        }
+    }
+}

--- a/tests/Integration/MSFT_xDnsServerForwarder.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerForwarder.config.ps1
@@ -53,3 +53,17 @@ configuration MSFT_xDnsServerForwarder_RemoveForwarders_Config
         }
     }
 }
+
+configuration MSFT_xDnsServerForwarder_SetUseRootHint_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerForwarder 'Integration_Test'
+        {
+            IsSingleInstance = 'Yes'
+            UseRootHint      = $true
+        }
+    }
+}

--- a/tests/Integration/MSFT_xDnsServerPrimaryZone.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerPrimaryZone.Integration.Tests.ps1
@@ -70,7 +70,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -Be 'None'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -120,7 +120,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -BeNullOrEmpty
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -170,7 +170,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -Be $ConfigurationData.AllNodes.ForwardZoneDynamicUpdate
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -220,7 +220,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -BeNullOrEmpty
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -270,7 +270,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -Be $ConfigurationData.AllNodes.ClassfulReverseZoneDynamicUpdate
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -320,7 +320,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -BeNullOrEmpty
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -370,7 +370,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -Be 'None'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -420,7 +420,7 @@ try
                 $resourceCurrentState.DynamicUpdate | Should -BeNullOrEmpty
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Integration/MSFT_xDnsServerRootHint.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerRootHint.Integration.Tests.ps1
@@ -68,7 +68,7 @@ try
                 $resourceCurrentState.NameServer       | Should -BeNullOrEmpty
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }
@@ -138,7 +138,7 @@ try
                 $nameServerHashtable['L.ROOT-SERVERS.NET.'] | Should -Be '199.7.83.42'
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Integration/MSFT_xDnsServerSetting.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerSetting.Integration.Tests.ps1
@@ -112,7 +112,7 @@ try
                 $resourceCurrentState.XfrConnectTimeout          | Should -Be $ConfigurationData.AllNodes.XfrConnectTimeout
             }
 
-            It 'Should return $true when Test-DscConfiguration is run' {
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
                 Test-DscConfiguration -Verbose | Should -Be 'True'
             }
         }

--- a/tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
+++ b/tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
@@ -149,8 +149,8 @@ try
 
                     Assert-MockCalled -CommandName Set-DnsServerForwarder -ParameterFilter {
                         # Only the property UseRootHint should exist in $PSBoundParameters.
-                        $UseRootHint -eq $true -and $null -eq $IPAddress
-                    } -Times 0 -Exactly -Scope It
+                        -not $PSBoundParameters.ContainsKey('IPAddress') -and $UseRootHint -eq $true
+                    } -Times 1 -Exactly -Scope It
                 }
             }
 

--- a/tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
+++ b/tests/Unit/MSFT_xDnsServerForwarder.Tests.ps1
@@ -97,7 +97,7 @@ try
                 Test-TargetResource @testParams | Should Be $true
             }
 
-            It 'Passes when forwarders match but root hint do not and are not spcified' {
+            It 'Passes when forwarders match but root hint do not and are not specified' {
                 Mock -CommandName Get-DnsServerForwarder -MockWith { return $fakeUseRootHint }
                 Test-TargetResource @testParamLimited | Should Be $true
             }
@@ -122,6 +122,38 @@ try
                 Set-TargetResource @testParams
                 Assert-MockCalled -CommandName Set-DnsServerForwarder -Times 1 -Exactly -Scope It
             }
+
+            Context 'When removing all forwarders' {
+                It "Should call the correct mocks" {
+                    Mock -CommandName Set-DnsServerForwarder
+                    Mock -CommandName Remove-DnsServerForwarder
+                    Mock -CommandName Get-DnsServerForwarder -MockWith {
+                        return New-CimInstance -ClassName 'DnsServerForwarder' -Namespace 'root/Microsoft/Windows/DNS' -ClientOnly -Property @{
+                            IPAddress = @('1.1.1.1')
+                        }
+                    }
+
+                    Set-TargetResource -IsSingleInstance 'Yes' -IPAddresses @()
+
+                    Assert-MockCalled -CommandName Set-DnsServerForwarder -Times 0 -Exactly -Scope It
+                    Assert-MockCalled -CommandName Get-DnsServerForwarder -Times 1 -Exactly -Scope It
+                    Assert-MockCalled -CommandName Remove-DnsServerForwarder -Times 1 -Exactly -Scope It
+                }
+            }
+
+            Context 'When enforcing just parameter UseRootHint' {
+                It "Should call the correct mock with correct parameters" {
+                    Mock -CommandName Set-DnsServerForwarder
+
+                    Set-TargetResource -IsSingleInstance 'Yes' -UseRootHint $true
+
+                    Assert-MockCalled -CommandName Set-DnsServerForwarder -ParameterFilter {
+                        # Only the property UseRootHint should exist in $PSBoundParameters.
+                        $UseRootHint -eq $true -and $null -eq $IPAddress
+                    } -Times 0 -Exactly -Scope It
+                }
+            }
+
         }
     } #end InModuleScope
 }


### PR DESCRIPTION
 
#### Pull Request (PR) description
- xDnsServer
  - Update descript for It-block in all integration tests.
- xDnsServerForwarder
  - Added integration test (issue #170).
  - When providing an empty collection the resource will enforce that no
    forwarders are present.
  - Now it is possible to just enforce the property `UseRooHint` without
    changing forwarders.

#### This Pull Request (PR) fixes the following issues

- Fixes #170
- Closes #126

This continues and are based on work that @jmos5156 started in PR #126.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/186)
<!-- Reviewable:end -->
