### PR TITLE
xDnsServerZoneScope: Add integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added new resource to manage MX records
 - xDnsServerZoneScope
   - Added integration tests ([issue #177](https://github.com/dsccommunity/xDnsServer/issues/177)).
+  - New read-only property `ZoneFile` was added to return the zone scope
+    file name used for the zone scope.
 
 ### Changed
 
@@ -102,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - xDnsServerAdZone
   - Now the parameter `ComputerName` can be used without throwing an exception
     ([issue 79](https://github.com/PowerShell/xDnsServer/issues/79)).
+- xDnsServerZoneScope
+  - Correctly returns the zone scope name when calling `Get-TargetResource`.
 
 ## [1.16.0.0] - 2019-10-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added more examples.
 - xDnsRecordMx
   - Added new resource to manage MX records
+- xDnsServerZoneScope
+  - Added integration tests ([issue #177](https://github.com/dsccommunity/xDnsServer/issues/177)).
 
 ### Changed
 

--- a/source/DSCResources/MSFT_xDnsServerZoneScope/MSFT_xDnsServerZoneScope.psm1
+++ b/source/DSCResources/MSFT_xDnsServerZoneScope/MSFT_xDnsServerZoneScope.psm1
@@ -38,15 +38,17 @@ function Get-TargetResource
     if ($null -eq $record)
     {
         return @{
-            Name     = $Name
+            Name     = $ZoneScope
             ZoneName = $ZoneName
+            ZoneFile = $null
             Ensure   = 'Absent'
         }
     }
 
     return @{
-        Name     = $record.Name
+        Name     = $record.ZoneScope
         ZoneName = $record.ZoneName
+        ZoneFile = $record.FileName
         Ensure   = 'Present'
     }
 } #end function Get-TargetResource

--- a/source/DSCResources/MSFT_xDnsServerZoneScope/MSFT_xDnsServerZoneScope.psm1
+++ b/source/DSCResources/MSFT_xDnsServerZoneScope/MSFT_xDnsServerZoneScope.psm1
@@ -38,7 +38,7 @@ function Get-TargetResource
     if ($null -eq $record)
     {
         return @{
-            Name     = $ZoneScope
+            Name     = $Name
             ZoneName = $ZoneName
             ZoneFile = $null
             Ensure   = 'Absent'

--- a/source/DSCResources/MSFT_xDnsServerZoneScope/MSFT_xDnsServerZoneScope.schema.mof
+++ b/source/DSCResources/MSFT_xDnsServerZoneScope/MSFT_xDnsServerZoneScope.schema.mof
@@ -4,5 +4,5 @@ class MSFT_xDnsServerZoneScope : OMI_BaseResource
     [Key, Description("Specifies the name of the Zone Scope.")] string Name;
     [Key, Description("Specify the existing DNS Zone to add a scope to.")] string ZoneName;
     [Write, Description("Should this DNS Server Zone Scope be present or absent"), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Read, Description("Returns the zone scope filename.")] string ZoneFile;
 };
-

--- a/tests/Integration/MSFT_xDnsServerZoneScope.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerZoneScope.Integration.Tests.ps1
@@ -95,6 +95,7 @@ try
                 $resourceCurrentState.Ensure   | Should -Be 'Present'
                 $resourceCurrentState.Name     | Should -Be $ConfigurationData.AllNodes.ZoneScopeName
                 $resourceCurrentState.ZoneName | Should -Be $ConfigurationData.AllNodes.ForwardZoneName
+                $resourceCurrentState.FileName | Should -Be ('{0}.dns' -f $ConfigurationData.AllNodes.ZoneScopeName)
             }
 
             It 'Should return ''True'' when Test-DscConfiguration is run' {
@@ -144,6 +145,7 @@ try
                 $resourceCurrentState.Ensure   | Should -Be 'Absent'
                 $resourceCurrentState.Name     | Should -Be $ConfigurationData.AllNodes.ZoneScopeName
                 $resourceCurrentState.ZoneName | Should -Be $ConfigurationData.AllNodes.ForwardZoneName
+                $resourceCurrentState.FileName | Should -BeNullOrEmpty
             }
 
             It 'Should return ''True'' when Test-DscConfiguration is run' {

--- a/tests/Integration/MSFT_xDnsServerZoneScope.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerZoneScope.Integration.Tests.ps1
@@ -95,7 +95,7 @@ try
                 $resourceCurrentState.Ensure   | Should -Be 'Present'
                 $resourceCurrentState.Name     | Should -Be $ConfigurationData.AllNodes.ZoneScopeName
                 $resourceCurrentState.ZoneName | Should -Be $ConfigurationData.AllNodes.ForwardZoneName
-                $resourceCurrentState.FileName | Should -Be ('{0}.dns' -f $ConfigurationData.AllNodes.ZoneScopeName)
+                $resourceCurrentState.ZoneFile | Should -Be ('{0}.dns' -f $ConfigurationData.AllNodes.ZoneScopeName)
             }
 
             It 'Should return ''True'' when Test-DscConfiguration is run' {
@@ -145,7 +145,7 @@ try
                 $resourceCurrentState.Ensure   | Should -Be 'Absent'
                 $resourceCurrentState.Name     | Should -Be $ConfigurationData.AllNodes.ZoneScopeName
                 $resourceCurrentState.ZoneName | Should -Be $ConfigurationData.AllNodes.ForwardZoneName
-                $resourceCurrentState.FileName | Should -BeNullOrEmpty
+                $resourceCurrentState.ZoneFile | Should -BeNullOrEmpty
             }
 
             It 'Should return ''True'' when Test-DscConfiguration is run' {

--- a/tests/Integration/MSFT_xDnsServerZoneScope.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerZoneScope.Integration.Tests.ps1
@@ -1,0 +1,188 @@
+$script:dscModuleName   = 'xDnsServer'
+$script:dscResourceFriendlyName = 'xDnsServerZoneScope'
+$script:dscResourceName = "MSFT_$($script:dscResourceFriendlyName)"
+
+try
+{
+    Import-Module -Name DscResource.Test -Force -ErrorAction 'Stop'
+}
+catch [System.IO.FileNotFoundException]
+{
+    throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -Tasks build" first.'
+}
+
+$script:testEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:dscModuleName `
+    -DSCResourceName $script:dscResourceName `
+    -ResourceType 'Mof' `
+    -TestType 'Integration'
+
+try
+{
+    $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
+    . $configFile
+
+    Describe "$($script:dscResourceName)_Integration" {
+        BeforeAll {
+            $resourceId = "[$($script:dscResourceFriendlyName)]Integration_Test"
+        }
+
+        $configurationName = "$($script:dscResourceName)_Prerequisites_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_AddZoneScope_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure   | Should -Be 'Present'
+                $resourceCurrentState.Name     | Should -Be $ConfigurationData.AllNodes.ZoneScopeName
+                $resourceCurrentState.ZoneName | Should -Be $ConfigurationData.AllNodes.ForwardZoneName
+            }
+
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_RemoveZoneScope_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                {
+                    $script:currentConfiguration = Get-DscConfiguration -Verbose -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq $configurationName `
+                    -and $_.ResourceId -eq $resourceId
+                }
+
+                $resourceCurrentState.Ensure   | Should -Be 'Absent'
+                $resourceCurrentState.Name     | Should -Be $ConfigurationData.AllNodes.ZoneScopeName
+                $resourceCurrentState.ZoneName | Should -Be $ConfigurationData.AllNodes.ForwardZoneName
+            }
+
+            It 'Should return ''True'' when Test-DscConfiguration is run' {
+                Test-DscConfiguration -Verbose | Should -Be 'True'
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+
+        $configurationName = "$($script:dscResourceName)_Cleanup_Config"
+
+        Context ('When using configuration {0}' -f $configurationName) {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    $configurationParameters = @{
+                        OutputPath        = $TestDrive
+                        ConfigurationData = $ConfigurationData
+                    }
+
+                    & $configurationName @configurationParameters
+
+                    $startDscConfigurationParameters = @{
+                        Path         = $TestDrive
+                        ComputerName = 'localhost'
+                        Wait         = $true
+                        Verbose      = $true
+                        Force        = $true
+                        ErrorAction  = 'Stop'
+                    }
+
+                    Start-DscConfiguration @startDscConfigurationParameters
+                } | Should -Not -Throw
+            }
+        }
+
+        Wait-ForIdleLcm -Clear
+    }
+}
+finally
+{
+    Restore-TestEnvironment -TestEnvironment $script:testEnvironment
+}

--- a/tests/Integration/MSFT_xDnsServerZoneScope.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerZoneScope.config.ps1
@@ -1,0 +1,68 @@
+$ConfigurationData = @{
+    AllNodes = @(
+        @{
+            NodeName        = 'localhost'
+            CertificateFile = $env:DscPublicCertificatePath
+
+            ForwardZoneName = 'dsc.test'
+            ZoneScopeName   = 'dsc_Europe'
+        }
+    )
+}
+
+configuration MSFT_xDnsServerZoneScope_Prerequisites_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerPrimaryZone 'ForwardZone'
+        {
+            Name = $Node.ForwardZoneName
+        }
+    }
+}
+
+configuration MSFT_xDnsServerZoneScope_AddZoneScope_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerZoneScope 'Integration_Test'
+        {
+            Name     = $Node.ZoneScopeName
+            ZoneName = $Node.ForwardZoneName
+        }
+    }
+}
+
+configuration MSFT_xDnsServerZoneScope_RemoveZoneScope_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerZoneScope 'Integration_Test'
+        {
+            Ensure   = 'Absent'
+            Name     = $Node.ZoneScopeName
+            ZoneName = $Node.ForwardZoneName
+        }
+    }
+}
+
+
+configuration MSFT_xDnsServerZoneScope_Cleanup_Config
+{
+    Import-DscResource -ModuleName 'xDnsServer'
+
+    node $AllNodes.NodeName
+    {
+        xDnsServerPrimaryZone 'ForwardZone'
+        {
+            Ensure = 'Absent'
+            Name   = $Node.ForwardZoneName
+        }
+    }
+}

--- a/tests/Unit/MSFT_xDnsServerZoneScope.Tests.ps1
+++ b/tests/Unit/MSFT_xDnsServerZoneScope.Tests.ps1
@@ -35,8 +35,9 @@ try
         $mocks = @{
             ZoneScopePresent = {
                 [PSCustomObject]@{
-                    ZoneName = 'contoso.com'
-                    Name     = 'ZoneScope'
+                    ZoneName  = 'contoso.com'
+                    ZoneScope = 'ZoneScope'
+                    FileName = 'ZoneScope.dns'
                 }
             }
             Absent  = { }
@@ -53,6 +54,7 @@ try
                     $getTargetResourceResult.Ensure | Should -Be 'Present'
                     $getTargetResourceResult.Name | Should -Be 'ZoneScope'
                     $getTargetResourceResult.ZoneName | Should -Be 'contoso.com'
+                    $getTargetResourceResult.ZoneFile | Should -Be 'ZoneScope.dns'
 
                     Assert-MockCalled -CommandName Get-DnsServerZoneScope -Exactly -Times 1 -Scope It
                 }


### PR DESCRIPTION

#### Pull Request (PR) description
- xDnsServerZoneScope
  - Added integration tests (issue #177).
  - New read-only property `ZoneFile` was added to return the zone scope
    file name used for the zone scope.
  - Correctly returns the zone scope name when calling `Get-TargetResource`.

#### This Pull Request (PR) fixes the following issues

- Fixes #177

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/188)
<!-- Reviewable:end -->
