### PR TITLE
BREAKING CHANGE: xDnsServerSetting: Remove properties `Forwarders` and `ForwardingTimeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- xDnsServerSetting
+  - BREAKING CHANGE: The properties `Forwarders` and `ForwardingTimeout` has
+    been removed ([issue #192](https://github.com/dsccommunity/xDnsServer/issues/192)).
+    Use the resource _xDnsServerForwarder_ to enforce these properties.
+
 ## [2.0.0] - 2021-03-26
 
 ### Deprecated

--- a/source/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.psm1
+++ b/source/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.psm1
@@ -6,7 +6,7 @@ Import-Module -Name $script:dnsServerDscCommonPath
 
 $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
-$properties = 'LocalNetPriority', 'AutoConfigFileZones', 'MaxCacheTTL', 'AddressAnswerLimit', 'UpdateOptions', 'DisableAutoReverseZones', 'StrictFileParsing', 'ForwardingTimeout', 'NoRecursion', 'DisjointNets', 'Forwarders', 'EnableDirectoryPartitions', 'XfrConnectTimeout', 'AllowUpdate', 'DsAvailable', 'BootMethod', 'LooseWildcarding', 'DsPollingInterval', 'BindSecondaries', 'LogLevel', 'AutoCacheUpdate', 'EnableDnsSec', 'EnableEDnsProbes', 'NameCheckFlag', 'EDnsCacheTimeout', 'SendPort', 'WriteAuthorityNS', 'IsSlave', 'RecursionTimeout', 'ListenAddresses', 'DsTombstoneInterval', 'RecursionRetry', 'RpcProtocol', 'SecureResponses', 'RoundRobin', 'ForwardDelegations', 'MaxNegativeCacheTTL'
+$properties = 'LocalNetPriority', 'AutoConfigFileZones', 'MaxCacheTTL', 'AddressAnswerLimit', 'UpdateOptions', 'DisableAutoReverseZones', 'StrictFileParsing', 'NoRecursion', 'DisjointNets', 'EnableDirectoryPartitions', 'XfrConnectTimeout', 'AllowUpdate', 'DsAvailable', 'BootMethod', 'LooseWildcarding', 'DsPollingInterval', 'BindSecondaries', 'LogLevel', 'AutoCacheUpdate', 'EnableDnsSec', 'EnableEDnsProbes', 'NameCheckFlag', 'EDnsCacheTimeout', 'SendPort', 'WriteAuthorityNS', 'IsSlave', 'RecursionTimeout', 'ListenAddresses', 'DsTombstoneInterval', 'RecursionRetry', 'RpcProtocol', 'SecureResponses', 'RoundRobin', 'ForwardDelegations', 'MaxNegativeCacheTTL'
 
 <#
     .SYNOPSIS
@@ -111,14 +111,6 @@ function Get-TargetResource
 
     .PARAMETER ForwardDelegations
         Specifies whether queries to delegated sub-zones are forwarded.
-
-    .PARAMETER Forwarders
-        Enumerates the list of IP addresses of Forwarders to which the DNS Server
-        forwards queries.
-
-    .PARAMETER ForwardingTimeout
-        Time, in seconds, a DNS Server forwarding a query will wait for resolution
-        from the forwarder before attempting to resolve the query itself.
 
     .PARAMETER IsSlave
         TRUE if the DNS server does not use recursion when name-resolution through
@@ -255,14 +247,6 @@ function Set-TargetResource
         [Parameter()]
         [uint32]
         $ForwardDelegations,
-
-        [Parameter()]
-        [string[]]
-        $Forwarders,
-
-        [Parameter()]
-        [uint32]
-        $ForwardingTimeout,
 
         [Parameter()]
         [bool]
@@ -442,14 +426,6 @@ function Set-TargetResource
     .PARAMETER ForwardDelegations
         Specifies whether queries to delegated sub-zones are forwarded.
 
-    .PARAMETER Forwarders
-        Enumerates the list of IP addresses of Forwarders to which the DNS Server
-        forwards queries.
-
-    .PARAMETER ForwardingTimeout
-        Time, in seconds, a DNS Server forwarding a query will wait for resolution
-        from the forwarder before attempting to resolve the query itself.
-
     .PARAMETER IsSlave
         TRUE if the DNS server does not use recursion when name-resolution through
         forwarders fails.
@@ -586,14 +562,6 @@ function Test-TargetResource
         [Parameter()]
         [uint32]
         $ForwardDelegations,
-
-        [Parameter()]
-        [string[]]
-        $Forwarders,
-
-        [Parameter()]
-        [uint32]
-        $ForwardingTimeout,
 
         [Parameter()]
         [bool]

--- a/source/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.schema.mof
+++ b/source/DSCResources/MSFT_xDnsServerSetting/MSFT_xDnsServerSetting.schema.mof
@@ -17,8 +17,6 @@ class MSFT_xDnsServerSetting : OMI_BaseResource
     [Write, Description("Specifies whether the DNS Server includes DNSSEC-specific RRs, KEY, SIG, and NXT in a response.")] Uint32 EnableDnsSec;
     [Write, Description("Specifies the behavior of the DNS Server. When TRUE, the DNS Server always responds with OPT resource records according to RFC 2671, unless the remote server has indicated it does not support EDNS in a prior exchange. If FALSE, the DNS Server responds to queries with OPTs only if OPTs are sent in the original query.")] Boolean EnableEDnsProbes;
     [Write, Description("Specifies whether queries to delegated sub-zones are forwarded.")] Uint32 ForwardDelegations;
-    [Write, Description("Enumerates the list of IP addresses of Forwarders to which the DNS Server forwards queries.")] String Forwarders[];
-    [Write, Description("Time, in seconds, a DNS Server forwarding a query will wait for resolution from the forwarder before attempting to resolve the query itself.")] Uint32 ForwardingTimeout;
     [Write, Description("TRUE if the DNS server does not use recursion when name-resolution through forwarders fails.")] Boolean IsSlave;
     [Write, Description("Enumerates the list of IP addresses on which the DNS Server can receive queries.")] String ListenAddresses[];
     [Write, Description("Indicates whether the DNS Server gives priority to the local net address when returning A records.")] Boolean LocalNetPriority;

--- a/source/Examples/Resources/xDnsServerSetting/1-xDnsServerSetting_CurrentNode_Config.ps1
+++ b/source/Examples/Resources/xDnsServerSetting/1-xDnsServerSetting_CurrentNode_Config.ps1
@@ -51,7 +51,6 @@ Configuration xDnsServerSetting_CurrentNode_Config
             DnsServer           = 'localhost'
             ListenAddresses    = '10.0.0.4'
             IsSlave            = $true
-            Forwarders         = @('168.63.129.16', '168.63.129.18')
             RoundRobin         = $true
             LocalNetPriority   = $true
             SecureResponses    = $true

--- a/source/Examples/Resources/xDnsServerSetting/2-xDnsServerSetting_RemoteNode_Config.ps1
+++ b/source/Examples/Resources/xDnsServerSetting/2-xDnsServerSetting_RemoteNode_Config.ps1
@@ -51,7 +51,6 @@ Configuration xDnsServerSetting_RemoteNode_Config
             DnsServer           = 'dns1.company.local'
             ListenAddresses    = '10.0.0.4'
             IsSlave            = $true
-            Forwarders         = @('168.63.129.16', '168.63.129.18')
             RoundRobin         = $true
             LocalNetPriority   = $true
             SecureResponses    = $true

--- a/tests/Integration/MSFT_xDnsServerSetting.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xDnsServerSetting.Integration.Tests.ps1
@@ -81,8 +81,6 @@ try
                 $resourceCurrentState.EnableDnsSec               | Should -Be $ConfigurationData.AllNodes.EnableDnsSec
                 $resourceCurrentState.EnableEDnsProbes           | Should -Be $ConfigurationData.AllNodes.EnableEDnsProbes
                 $resourceCurrentState.ForwardDelegations         | Should -Be $ConfigurationData.AllNodes.ForwardDelegations
-                $resourceCurrentState.Forwarders                 | Should -Be $ConfigurationData.AllNodes.Forwarders
-                $resourceCurrentState.ForwardingTimeout          | Should -Be $ConfigurationData.AllNodes.ForwardingTimeout
                 $resourceCurrentState.IsSlave                    | Should -Be $ConfigurationData.AllNodes.IsSlave
                 $resourceCurrentState.ListenAddresses            | Should -Be $ConfigurationData.AllNodes.ListenAddresses
                 $resourceCurrentState.LocalNetPriority           | Should -Be $ConfigurationData.AllNodes.LocalNetPriority

--- a/tests/Integration/MSFT_xDnsServerSetting.config.ps1
+++ b/tests/Integration/MSFT_xDnsServerSetting.config.ps1
@@ -29,8 +29,6 @@ $ConfigurationData = @{
             EnableDnsSec              = 1
             EnableEDnsProbes          = $true
             ForwardDelegations        = 0
-            Forwarders                = @('168.63.129.16')
-            ForwardingTimeout         = 3
             IsSlave                   = $false
             <#
                 At least one of the listening IP addresses that is specified must
@@ -84,8 +82,6 @@ Configuration MSFT_xDnsServerSetting_SetSettings_config
             EnableDnsSec              = $Node.EnableDnsSec
             EnableEDnsProbes          = $Node.EnableEDnsProbes
             ForwardDelegations        = $Node.ForwardDelegations
-            Forwarders                = $Node.Forwarders
-            ForwardingTimeout         = $Node.ForwardingTimeout
             IsSlave                   = $Node.IsSlave
             ListenAddresses           = $Node.ListenAddresses
             LocalNetPriority          = $Node.LocalNetPriority

--- a/tests/Unit/MSFT_xDnsServerSetting.Tests.ps1
+++ b/tests/Unit/MSFT_xDnsServerSetting.Tests.ps1
@@ -49,8 +49,6 @@ try
             EnableDnsSec              = 0
             EnableEDnsProbes          = $false
             ForwardDelegations        = 1
-            Forwarders                = '8.8.8.8'
-            ForwardingTimeout         = 4
             IsSlave                   = $true
             ListenAddresses           = '192.168.0.10', '192.168.0.11'
             LocalNetPriority          = $false
@@ -99,8 +97,6 @@ try
             EnableDnsSec              = 1
             EnableEDnsProbes          = $true
             ForwardDelegations        = 0
-            Forwarders                = { 168.63.129.16 }
-            ForwardingTimeout         = 3
             IsSlave                   = $false
             ListenAddresses           = $null
             LocalNetPriority          = $true


### PR DESCRIPTION

### Pull Request (PR) description
#### Removed

- xDnsServerSetting
  - BREAKING CHANGE: The properties `Forwarders` and `ForwardingTimeout` has
    been removed (issue #192). Use the resource _xDnsServerForwarder_ to enforce
    these properties.

### This Pull Request (PR) fixes the following issues

- Fixes #192

### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xdnsserver/231)
<!-- Reviewable:end -->
